### PR TITLE
Fixed: Averaging categories are now using the correct type, TestGetGradeF now using appropriate values

### DIFF
--- a/grade-calculator/grade_calculator.go
+++ b/grade-calculator/grade_calculator.go
@@ -80,7 +80,7 @@ func (gc *GradeCalculator) AddGrade(name string, grade int, gradeType GradeType)
 func (gc *GradeCalculator) calculateNumericalGrade() int {
 	assignment_average := computeAverage(gc.assignments)
 	exam_average := computeAverage(gc.exams)
-	essay_average := computeAverage(gc.exams)
+	essay_average := computeAverage(gc.essays)
 
 	weighted_grade := float64(assignment_average)*.5 + float64(exam_average)*.35 + float64(essay_average)*.15
 
@@ -90,8 +90,8 @@ func (gc *GradeCalculator) calculateNumericalGrade() int {
 func computeAverage(grades []Grade) int {
 	sum := 0
 
-	for grade, _ := range grades {
-		sum += grade
+	for _, grade:= range grades {
+		sum += grade.Grade
 	}
 
 	return sum / len(grades)

--- a/grade-calculator/grade_calculator_test.go
+++ b/grade-calculator/grade_calculator_test.go
@@ -39,9 +39,9 @@ func TestGetGradeF(t *testing.T) {
 
 	gradeCalculator := NewGradeCalculator()
 
-	gradeCalculator.AddGrade("open source assignment", 100, Assignment)
+	gradeCalculator.AddGrade("open source assignment", 30, Assignment)
 	gradeCalculator.AddGrade("exam 1", 95, Exam)
-	gradeCalculator.AddGrade("essay on ai ethics", 91, Essay)
+	gradeCalculator.AddGrade("essay on ai ethics", 40, Essay)
 
 	actual_value := gradeCalculator.GetFinalGrade()
 


### PR DESCRIPTION
Within grade_calculator.go
essay average needed to have computeAverage(gc.essays) instead of 'gc.essays'
computeAverage for loop changed to get values from grades

Within grade_calculator_test.go
TestGetGradeF values changed to actually reflect a student recieving a 'F' instead of an 'A'