### PR TITLE
changing_internals: single list for all grades instead of three separate ones

### DIFF
--- a/grade-calculator/grade_calculator.go
+++ b/grade-calculator/grade_calculator.go
@@ -1,9 +1,7 @@
 package esepunittests
 
 type GradeCalculator struct {
-	assignments []Grade
-	exams       []Grade
-	essays      []Grade
+	grades []Grade
 }
 
 type GradeType int
@@ -32,9 +30,7 @@ type Grade struct {
 
 func NewGradeCalculator() *GradeCalculator {
 	return &GradeCalculator{
-		assignments: make([]Grade, 0),
-		exams:       make([]Grade, 0),
-		essays:      make([]Grade, 0),
+		grades : make([]Grade, 0),
 	}
 }
 
@@ -55,44 +51,36 @@ func (gc *GradeCalculator) GetFinalGrade() string {
 }
 
 func (gc *GradeCalculator) AddGrade(name string, grade int, gradeType GradeType) {
-	switch gradeType {
-	case Assignment:
-		gc.assignments = append(gc.assignments, Grade{
-			Name:  name,
-			Grade: grade,
-			Type:  Assignment,
-		})
-	case Exam:
-		gc.exams = append(gc.exams, Grade{
-			Name:  name,
-			Grade: grade,
-			Type:  Exam,
-		})
-	case Essay:
-		gc.essays = append(gc.essays, Grade{
-			Name:  name,
-			Grade: grade,
-			Type:  Essay,
-		})
-	}
+	gc.grades = append(gc.grades, Grade{
+		Name: name,
+		Grade: grade,
+		Type: gradeType,
+	})
 }
 
 func (gc *GradeCalculator) calculateNumericalGrade() int {
-	assignment_average := computeAverage(gc.assignments)
-	exam_average := computeAverage(gc.exams)
-	essay_average := computeAverage(gc.essays)
+	assignment_average := computeAverage(gc.grades, Assignment)
+	exam_average := computeAverage(gc.grades, Exam)
+	essay_average := computeAverage(gc.grades, Essay)
 
 	weighted_grade := float64(assignment_average)*.5 + float64(exam_average)*.35 + float64(essay_average)*.15
 
 	return int(weighted_grade)
 }
 
-func computeAverage(grades []Grade) int {
+func computeAverage(grades []Grade, t GradeType) int {
+	
 	sum := 0
-
-	for _, grade:= range grades {
-		sum += grade.Grade
+	count := 0
+	for _, i:= range grades {
+		if i.Type == t{
+			sum += i.Grade
+			count++
+		}
+	}
+	if count == 0{
+		return 0
 	}
 
-	return sum / len(grades)
+	return sum / count
 }


### PR DESCRIPTION
These are the changes within grade_calculator.go:
Types have been replaced with one type (Grades)
NewGradeCalculator only intializes Grades to empty instead of the three types
No more switch statement for each type, instead appends a new struct to grades with a name, grade, and grade type
Calculates each average based on the type of assignment inputted into grades
Averages are calculated by summing all of the same type and then dividing by the number assessments in that type